### PR TITLE
Add catch for NoClassDefFoundError

### DIFF
--- a/src/main/java/fi/luontola/clojure_native_image_agent/Agent.java
+++ b/src/main/java/fi/luontola/clojure_native_image_agent/Agent.java
@@ -154,7 +154,7 @@ public class Agent {
             // were loaded.
             try {
                 Class.forName(className);
-            } catch (ClassNotFoundException e) {
+            } catch (ClassNotFoundException | NoClassDefFoundError e) {
                 // Some classes such as clojure.tools.logging$eval1 fail to load,
                 // likely due to runtime code generation. It should be okay to ignore them.
                 log("WARNING: Cannot initialize class: " + e);


### PR DESCRIPTION
Adds catch of `NoClassDefFoundError` which is thrown for some classes like `io.netty.channel.epoll.Native`, alongside the existing catch for `ClassNotFoundException`:

```
Exception in thread "main" java.lang.reflect.InvocationTargetException
        at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
        at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
        at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
        at java.base/java.lang.reflect.Method.invoke(Method.java:566)
        at java.instrument/sun.instrument.InstrumentationImpl.loadClassAndStartAgent(InstrumentationImpl.java:513)
        at java.instrument/sun.instrument.InstrumentationImpl.loadClassAndCallPremain(InstrumentationImpl.java:525)
Caused by: java.lang.NoClassDefFoundError: Could not initialize class io.netty.channel.epoll.Native
        at java.base/java.lang.Class.forName0(Native Method)
        at java.base/java.lang.Class.forName(Class.java:315)
        at fi.luontola.clojure_native_image_agent.Agent.trackRecursivelyLoadedClasses(Agent.java:156)
        at fi.luontola.clojure_native_image_agent.Agent.premain(Agent.java:114)
        ... 6 more
*** java.lang.instrument ASSERTION FAILED ***: "result" with message agent load/premain call failed at ./src/java.instrument/share/native/libinstrument/JPLISAgent.c line: 422
FATAL ERROR in native method: processing of -javaagent failed, processJavaStart failed
```

Thanks for this utility, it saves tons of work!